### PR TITLE
Corrige o padding da landing page

### DIFF
--- a/_sass/landing-page.scss
+++ b/_sass/landing-page.scss
@@ -5,7 +5,6 @@
 	background-repeat: no-repeat;
 	background-size: cover;
 	background-position: center center;
-	padding-top: 50px;
 
 	&:before {
 		content: "";


### PR DESCRIPTION
A landing page estava com padding top de 50 px. Não sei de onde veio mas causava
uma barra preta separando o menú do vídeo.