### PR TITLE
Atualiza eventos

### DIFF
--- a/_eventos/2019-03-24-introgit.md
+++ b/_eventos/2019-03-24-introgit.md
@@ -16,7 +16,7 @@ instructor_image: /images/members/perkles.jpg
 instructor_name: Otávio Perkles
 instructor_contact: https://perkles.dev/
 inscription_form: https://www.sympla.com.br/introducao-ao-git-e-github__509369
-allow_inscription: open
+allow_inscription: no
 files: /images/files/Piroll.rar
 ---
 

--- a/_eventos/2019-03-24-introgit.md
+++ b/_eventos/2019-03-24-introgit.md
@@ -8,7 +8,7 @@ categories:
   - Intermediário
   - DevOps
   - Git e GitHub
-status: open
+status: closed
 image: /images/events/01-cover.png
 image_card: /images/events/bootcamp.png
 card_hexa: 1e1f1a

--- a/_includes/list-events.html
+++ b/_includes/list-events.html
@@ -28,9 +28,9 @@
 			</div>
 		</div>
 
-		<h3>Eventos passados:</h3>
-
+		
 	{% else %}
+
 		<div class="blog-card">
 			<div class="meta">
 				<div class="photo" style="background-image:url({{event.image_card}});">


### PR DESCRIPTION
Atualiza o status do evento de open para closed. Isso retira o label "próximos eventos" e "eventos futuros" da página de eventos. 
Mudada também o campo "Allow_inscription" para 'no' dessa forma não é mais possível acessar o link de inscrição do evento.